### PR TITLE
Strict types

### DIFF
--- a/doclib/msgpack/error.rb
+++ b/doclib/msgpack/error.rb
@@ -1,5 +1,8 @@
 module MessagePack
 
+  class PackError < StandardError
+  end
+
   class UnpackError < StandardError
   end
 

--- a/ext/msgpack/factory_class.c
+++ b/ext/msgpack/factory_class.c
@@ -32,6 +32,7 @@ struct msgpack_factory_t {
     msgpack_packer_ext_registry_t pkrg;
     msgpack_unpacker_ext_registry_t ukrg;
     bool has_symbol_ext_type;
+    bool strict_types;
 };
 
 #define FACTORY(from, name) \
@@ -74,13 +75,18 @@ static VALUE Factory_initialize(int argc, VALUE* argv, VALUE self)
 
     fc->has_symbol_ext_type = false;
 
-    switch (argc) {
-    case 0:
-        break;
-    default:
-        // TODO options is not supported yet
-        rb_raise(rb_eArgError, "wrong number of arguments (%d for 0)", argc);
+    VALUE options = Qnil;
+    VALUE strict = Qfalse;
+    rb_scan_args(argc, argv, "0:", &options);
+
+    if (!NIL_P(options)) {
+        static ID keyword_ids[1];
+        if (!keyword_ids[0])
+            keyword_ids[0] = rb_intern("strict");
+        rb_get_kwargs(options, keyword_ids, 0, 1, &strict);
     }
+
+    fc->strict_types = RB_TEST(strict);
 
     return Qnil;
 }
@@ -98,6 +104,7 @@ VALUE MessagePack_Factory_packer(int argc, VALUE* argv, VALUE self)
     msgpack_packer_ext_registry_destroy(&pk->ext_registry);
     msgpack_packer_ext_registry_dup(&fc->pkrg, &pk->ext_registry);
     pk->has_symbol_ext_type = fc->has_symbol_ext_type;
+    pk->strict_types = fc->strict_types;
 
     return packer;
 }
@@ -204,6 +211,12 @@ static VALUE Factory_register_type(int argc, VALUE* argv, VALUE self)
     return Qnil;
 }
 
+static VALUE MessagePack_Factory_strict_types_p(VALUE self)
+{
+    FACTORY(self, fc);
+    return fc->strict_types ? Qtrue : Qfalse;
+}
+
 void MessagePack_Factory_module_init(VALUE mMessagePack)
 {
     cMessagePack_Factory = rb_define_class_under(mMessagePack, "Factory", rb_cObject);
@@ -217,4 +230,6 @@ void MessagePack_Factory_module_init(VALUE mMessagePack)
 
     rb_define_private_method(cMessagePack_Factory, "registered_types_internal", Factory_registered_types_internal, 0);
     rb_define_method(cMessagePack_Factory, "register_type", Factory_register_type, -1);
+
+    rb_define_method(cMessagePack_Factory, "strict_types?", MessagePack_Factory_strict_types_p, 0);
 }

--- a/ext/msgpack/packer.h
+++ b/ext/msgpack/packer.h
@@ -33,6 +33,7 @@ struct msgpack_packer_t {
 
     bool compatibility_mode;
     bool has_symbol_ext_type;
+    bool strict_types;
 
     ID to_msgpack_method;
     VALUE to_msgpack_arg;

--- a/ext/msgpack/packer_class.c
+++ b/ext/msgpack/packer_class.c
@@ -413,6 +413,12 @@ VALUE Packer_full_pack(VALUE self)
     return retval;
 }
 
+static VALUE Packer_strict_types_p(VALUE self)
+{
+    PACKER(self, pk);
+    return pk->strict_types ? Qtrue : Qfalse;
+}
+
 void MessagePack_Packer_module_init(VALUE mMessagePack)
 {
     s_to_msgpack = rb_intern("to_msgpack");
@@ -467,4 +473,6 @@ void MessagePack_Packer_module_init(VALUE mMessagePack)
     //Data_Get_Struct(s_packer_value, msgpack_packer_t, s_packer);
 
     rb_define_method(cMessagePack_Packer, "full_pack", Packer_full_pack, 0);
+
+    rb_define_method(cMessagePack_Packer, "strict_types?", Packer_strict_types_p, 0);
 }

--- a/lib/msgpack.rb
+++ b/lib/msgpack.rb
@@ -46,4 +46,8 @@ module MessagePack
 
   module_function :pack
   module_function :dump
+
+  class PackError < StandardError
+    attr_accessor :error_value
+  end
 end


### PR DESCRIPTION
We'd like an option which would allow a factory to enforce the condition that all core types (`String`, `Hash`, `Array`, etc.) are only accepted if the object is an instance of the class and not any subclass of it. This happens to be particularly important with `ActiveSupport::HashWithIndifferentAccess` which by default will be treated like a `Hash`, potentially with unexpected results.

Creating PR on Shopify/msgpack-ruby for now for discussion.